### PR TITLE
fix typo to call disconnect and loop_stop methods

### DIFF
--- a/mqtt_bridge/app.py
+++ b/mqtt_bridge/app.py
@@ -100,8 +100,8 @@ def mqtt_bridge_node():
         rclpy.spin(mqtt_node)
     except KeyboardInterrupt:
         mqtt_node.get_logger().info('Ctrl-C detected')
-        mqtt_client.disconnect
-        mqtt_client.loop_stop
+        mqtt_client.disconnect()
+        mqtt_client.loop_stop()
 
     mqtt_node.destroy_node()
 


### PR DESCRIPTION
There was a typo preventing the `disconnect` and `loop_stop` methods from being called.