### PR TITLE
enable arbitrary bridge keys without pre-specifying the amount

### DIFF
--- a/config/demo_params.yaml
+++ b/config/demo_params.yaml
@@ -10,7 +10,6 @@ mqtt_bridge_node:
       private_path: "device/001"
     #serializer: json:dumps
     #deserializer: json:loads
-    n_bridges: 6
     bridge:
       bridge1: ["mqtt_bridge.bridge:RosToMqttBridge","std_msgs.msg:Bool","/ping","ping"]
       bridge2: ["mqtt_bridge.bridge:MqttToRosBridge","std_msgs.msg:Bool","ping","/pong"]

--- a/mqtt_bridge/app.py
+++ b/mqtt_bridge/app.py
@@ -34,10 +34,9 @@ def mqtt_bridge_node():
     # load bridge parameters
     bridge_dict_keys = ["factory","msg_type","topic_from","topic_to"]
     bridge_params = []
-    total_bridges = mqtt_node.get_parameter("n_bridges").value
-    for i in range(total_bridges):
-        bridge_n = str((i % total_bridges) + 1)
-        bridge_param = mqtt_node.get_parameter('bridge.bridge'+bridge_n).value
+    bridges_list = filter(lambda key: key[:7] == "bridge.", mqtt_node._parameters.keys())
+    for bridge_name in bridges_list:
+        bridge_param = mqtt_node.get_parameter(bridge_name).value
         bridge_params.append(dict(zip(bridge_dict_keys,bridge_param)))
 
     #params = rospy.get_param("~", {})


### PR DESCRIPTION
Allow me to be intrusive and feel free to reject the PR.

I have removed the `n_bridges` parameter to favor a design where
1. developer is free to arbitrarily name the keys in the json file as long as they are nested under the `bridge` tag, and
2. the number of bridges is automatically detected.